### PR TITLE
fix error in post.py (self.post -> self.commit.post)

### DIFF
--- a/steem/post.py
+++ b/steem/post.py
@@ -285,7 +285,7 @@ class Post(dict):
             else:
                 new_meta = meta
 
-        return self.post(
+        return self.commit.post(
             original_post["title"],
             newbody,
             reply_identifier=reply_identifier,


### PR DESCRIPTION
Simple mistake. Easy fix. There is no `self.post()` in post.py... use `self.commit.post()` instead.