### PR TITLE
Fixes in post.py Post.edit()

### DIFF
--- a/steem/post.py
+++ b/steem/post.py
@@ -291,7 +291,7 @@ class Post(dict):
             reply_identifier=reply_identifier,
             author=original_post["author"],
             permlink=original_post["permlink"],
-            meta=new_meta,
+            json_metadata=new_meta,
         )
 
     def reply(self, body, title="", author="", meta=None):

--- a/steem/post.py
+++ b/steem/post.py
@@ -285,7 +285,7 @@ class Post(dict):
             else:
                 new_meta = meta
 
-        return self.post(
+        return self.commit.post(
             original_post["title"],
             newbody,
             reply_identifier=reply_identifier,


### PR DESCRIPTION
Error fixed: `self.post()` -> `self.commit.post()` and `meta` keyword updated to `json_metadata`.

Note that there is still an issue where the `original_post["json_metadata"].update(meta)` returns None.