### PR TITLE
Corrected sp_to_rshares math

### DIFF
--- a/steem/converter.py
+++ b/steem/converter.py
@@ -59,9 +59,16 @@ class Converter(object):
         # calculate our account voting shares (from vests), mine is 6.08b
         vesting_shares = int(self.sp_to_vests(sp) * 1e6)
 
+        # get props
+        props = self.steemd.get_dynamic_global_properties()
+
+        # determine voting power used
+        used_power = int((voting_power * vote_pct) / 10000);
+        max_vote_denom = props['vote_power_reserve_rate'] * (5*60*60*24) / (60*60*24);
+        used_power = int((used_power + max_vote_denom - 1) / max_vote_denom)
+
         # calculate vote rshares
-        power = (((voting_power * vote_pct) / 10000) / 200) + 1
-        rshares = (power * vesting_shares) / 10000
+        rshares = ((vesting_shares * used_power) / 10000)
 
         return rshares
 


### PR DESCRIPTION
I found I was getting incorrect results based on this method, so I dug into the code in steemit/steem, and discovered the math was being done improperly. 

https://github.com/steemit/steem/blob/8cd5f688d75092298bcffaa48a543ed9b01447a6/libraries/chain/steem_evaluator.cpp#L1169-L1190

I believe this pull request contains what the math should be to derive proper rshares for a given amount of SP.