### PR TITLE
Fix Error Causing Voting to Fail

### DIFF
--- a/steem/post.py
+++ b/steem/post.py
@@ -243,7 +243,7 @@ class Post(dict):
         """
         # Test if post is archived, if so, voting is worthless but just
         # pollutes the blockchain and account history
-        if not self.get('net_rshares'):
+        if self.get('net_rshares', None) == None:
             raise VotingInvalidOnArchivedPost
         return self.commit.vote(self.identifier, weight, account=voter)
 


### PR DESCRIPTION
Voting using `.vote()` checks if the post is archived, and if it is, it raises the `VotingInvalidOnArchivedPost` error.

However, prior to this fix, it checked if the `net_rshares` of the post was 0, which would also fire if the post did not have any votes on it yet. This fix allows posts that aren't archived but have 0 votes to be voted on.