### PR TITLE
Use correct testnet address prefix

### DIFF
--- a/steembase/base58.py
+++ b/steembase/base58.py
@@ -13,7 +13,7 @@ PREFIX = "STM"
 
 known_prefixes = [
     PREFIX,
-    "TEST",
+    "TST",
 ]
 
 


### PR DESCRIPTION
The testnet address prefix is defined in `steemd` [here](https://github.com/steemit/steem/blob/aee19938c9d121466496e56251619de4ecdf5455/libraries/protocol/include/steem/protocol/config.hpp#L18) as `"TST"`.  The `steem-python` code must be updated to match, or it will spew warnings when using this code to process testnet pubkeys.