### PR TITLE
propagate custom steemd instance to internal constructors

### DIFF
--- a/steem/blog.py
+++ b/steem/blog.py
@@ -42,7 +42,7 @@ class Blog:
     def __init__(self, account_name: str, comments_only=False, steemd_instance=None):
         self.steem = steemd_instance or shared_steemd_instance()
         self.comments_only = comments_only
-        self.account = Account(account_name)
+        self.account = Account(account_name, steemd_instance=self.steem)
         self.history = self.account.history_reverse(filter_by='comment')
         self.seen_items = set()
 
@@ -72,7 +72,8 @@ class Blog:
 
         unique = filter(ensure_unique, hist2)
 
-        serialized = filter(bool, map(silent(Post), unique))
+        postmap = [silent(Post(u, steemd_instance=self.steem)) for u in unique]
+        serialized = filter(bool, postmap)
 
         batch = take(limit, serialized)
         return batch

--- a/steem/cli.py
+++ b/steem/cli.py
@@ -958,7 +958,7 @@ def legacy():
         if not args.objects:
             t = PrettyTable(["Key", "Value"])
             t.align = "l"
-            blockchain = Blockchain(mode="head")
+            blockchain = Blockchain(mode="head", steemd_instance=steem)
             info = blockchain.info()
             median_price = steem.get_current_median_history_price()
             steem_per_mvest = (
@@ -978,7 +978,7 @@ def legacy():
         for obj in args.objects:
             # Block
             if re.match("^[0-9]*$", obj):
-                block = Block(obj)
+                block = Block(obj, steemd_instance=steem)
                 if block:
                     t = PrettyTable(["Key", "Value"])
                     t.align = "l"
@@ -993,7 +993,7 @@ def legacy():
             # Account name
             elif re.match("^[a-zA-Z0-9\-\._]{2,16}$", obj):
                 from math import log10
-                account = Account(obj)
+                account = Account(obj, steemd_instance=steem)
                 t = PrettyTable(["Key", "Value"])
                 t.align = "l"
                 for key in sorted(account):
@@ -1044,7 +1044,7 @@ def legacy():
                     print("Public Key not known" % obj)
             # Post identifier
             elif re.match(".*@.{3,16}/.*$", obj):
-                post = Post(obj)
+                post = Post(obj, steemd_instance=steem)
                 if post:
                     t = PrettyTable(["Key", "Value"])
                     t.align = "l"
@@ -1143,7 +1143,7 @@ def legacy():
         print(t)
 
     elif args.command == "upvote" or args.command == "downvote":
-        post = Post(args.post)
+        post = Post(args.post, steemd_instance=steem)
         if args.command == "downvote":
             weight = -float(args.weight)
         else:
@@ -1192,7 +1192,7 @@ def legacy():
     elif args.command == "balance":
         if args.account and isinstance(args.account, list):
             for account in args.account:
-                a = Account(account)
+                a = Account(account, steemd_instance=steem)
 
                 print("\n@%s" % a.name)
                 t = PrettyTable(["Account", "STEEM", "SBD", "VESTS"])
@@ -1247,7 +1247,7 @@ def legacy():
         print(t)
 
     elif args.command == "permissions":
-        account = Account(args.account)
+        account = Account(args.account, steemd_instance=steem)
         print_permissions(account)
 
     elif args.command == "allow":
@@ -1313,7 +1313,7 @@ def legacy():
         from steembase.account import PasswordKey
         import getpass
         password = getpass.getpass("Account Passphrase: ")
-        account = Account(args.account)
+        account = Account(args.account, steemd_instance=steem)
         imported = False
 
         if "owner" in args.roles:
@@ -1456,7 +1456,7 @@ def legacy():
 
         profile = Profile(keys, values)
 
-        account = Account(args.account)
+        account = Account(args.account, steemd_instance=steem)
         account["json_metadata"] = Profile(
             account["json_metadata"]
             if account["json_metadata"]
@@ -1471,7 +1471,7 @@ def legacy():
 
     elif args.command == "delprofile":
         from .profile import Profile
-        account = Account(args.account)
+        account = Account(args.account, steemd_instance=steem)
         account["json_metadata"] = Profile(account["json_metadata"])
 
         for var in args.variable:

--- a/steem/commit.py
+++ b/steem/commit.py
@@ -539,7 +539,7 @@ class Commit(object):
             remaining_fee = required_fee_steem - delegation_fee_steem
             if remaining_fee > 0:
                 required_sp = remaining_fee * delegated_sp_fee_mult
-                required_fee_vests = Converter().sp_to_vests(required_sp) + 1
+                required_fee_vests = Converter(self.steemd).sp_to_vests(required_sp) + 1
 
         s = {'creator': creator,
              'fee': '%s STEEM' % (delegation_fee_steem or required_fee_steem),
@@ -797,7 +797,7 @@ class Commit(object):
 
         # if no values were set by user, claim all outstanding balances on account
         if none(int(first(x.split(' '))) for x in [reward_sbd, reward_steem, reward_vests]):
-            a = Account(account)
+            a = Account(account, steemd_instance=self.steemd)
             reward_steem = a['reward_steem_balance']
             reward_sbd = a['reward_sbd_balance']
             reward_vests = a['reward_vesting_balance']

--- a/steem/wallet.py
+++ b/steem/wallet.py
@@ -336,7 +336,7 @@ class Wallet:
                     }
         else:
             try:
-                account = Account(name)
+                account = Account(name, steemd_instance=self.steemd)
             except:
                 return
             keyType = self.getKeyType(account, pub)


### PR DESCRIPTION
there are several internal Account()/Post()/Blockchain()/Block()/Converter() instances that use the default shared steemd instance even if a custom steemd instance is given to the constructors of the parent classes.