### PR TITLE
Appveyor added

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ install:
   - conda config --add channels wheeler-microfluidics
   - conda update -q conda
   - conda info -a
-  - conda install --yes nose conda-build path_helpers pycrypto setuptools pip 
+  - conda install --yes nose conda-build pycrypto setuptools pip 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   #- "pip install --disable-pip-version-check --user --upgrade pip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,12 +53,12 @@ install:
 
 build_script:
   # Build the compiled extension
-  - "pipenv install --three --dev"
-  - "pipenv install ."
+  - "python setup.py build"
+  - "python setup.py install --user"
 
 test_script:
   # Run the project tests
-  - "pipenv run py.test"
+  - "python setup.py test"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,13 +43,13 @@ install:
   - conda config --add channels wheeler-microfluidics
   - conda update -q conda
   - conda info -a
-  - conda install --yes nose conda-build path_helpers pycrypto setuptools pip pipenv 
+  - conda install --yes nose conda-build path_helpers pycrypto setuptools pip 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
   #- "pip install --disable-pip-version-check --user --upgrade pip"
   #- "python -m pip install -U pip setuptools"
   #- "pip install --user pycrypto Paramiko"
-  - "pip install --user --upgrade steem"
+  - "pip install --user --upgrade pipenv steem"
 
 build_script:
   # Build the compiled extension

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,74 @@
+# Based on https://github.com/ogrisel/python-appveyor-demo/blob/master/appveyor.yml
+
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
+
+  matrix:
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.3"
+      PYTHON_ARCH: "32"
+      MINICONDA: C:\Miniconda36
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.3"
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda36-x64
+
+install:
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  - ECHO "Installed SDKs:"
+  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+  #- set "PATH=%PYTHON%;%PYTHON%\\Scripts;%PYTHON%\\Tools\\Scripts;%PATH%"
+  - set "PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  #- set VCINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC"
+  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
+  - set CL=-FI"%VCINSTALLDIR%\INCLUDE\stdint.h"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda config --add channels conda-forge
+  - conda config --add channels wheeler-microfluidics
+  - conda update -q conda
+  - conda info -a
+  - conda install --yes nose conda-build path_helpers pycrypto setuptools pip pipenv 
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  #- "pip install --disable-pip-version-check --user --upgrade pip"
+  #- "python -m pip install -U pip setuptools"
+  #- "pip install --user pycrypto Paramiko"
+  - "pip install --user --upgrade steem"
+
+build_script:
+  # Build the compiled extension
+  - "pipenv install --three --dev"
+  - "pipenv install ."
+
+test_script:
+  # Run the project tests
+  - "pipenv run py.test"
+
+after_test:
+  # If tests are successful, create binary packages for the project.
+  - "pip install wheel"
+  - "python setup.py bdist_wheel"
+  #- "%CMD_IN_ENV% python setup.py bdist_wininst"
+  #- "%CMD_IN_ENV% python setup.py bdist_msi"
+  - ps: "ls dist"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: dist\*
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,3 @@ after_test:
 artifacts:
   # Archive the generated packages in the ci.appveyor.com build report.
   - path: dist\*
-


### PR DESCRIPTION
Miniconda is used, as pyCrypto is broken without patch under windows. The conda-forge package for pyCrypto is patched and can be installed unter windows.

Build and tests are working:
https://ci.appveyor.com/project/holger80/steem-python/build/