### PR TITLE
base58.py: add GLS to known_prefixes

### DIFF
--- a/steembase/base58.py
+++ b/steembase/base58.py
@@ -12,6 +12,7 @@ PREFIX = "STM"
 
 known_prefixes = [
     PREFIX,
+    "GLS",
     "TST",
 ]
 


### PR DESCRIPTION
This eliminates the following warning:

Format GLS unkown. You've been warned!