### PR TITLE
Fixed storage.py to properly reference compat_bytes

### DIFF
--- a/steem/utils.py
+++ b/steem/utils.py
@@ -410,7 +410,7 @@ def compat_bytes(item, encoding=None):
 
     This is the expected and necessary behavior across both platforms.
 
-    w/ future_bytes method, we will ensure that the correct bytes method is always invoked, avoiding the `str` alias in
+    w/ compat_bytes method, we will ensure that the correct bytes method is always invoked, avoiding the `str` alias in
     2.7.
 
     :param item: this is the object who's bytes method needs to be invoked

--- a/steembase/storage.py
+++ b/steembase/storage.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from appdirs import user_data_dir
 
 from steem.aes import AESCipher
+from steem.utils import compat_bytes
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -399,7 +400,7 @@ class MasterPassword(object):
     def deriveChecksum(self, s):
         """ Derive the checksum
         """
-        checksum = hashlib.sha256(future_bytes(s, "ascii")).hexdigest()
+        checksum = hashlib.sha256(compat_bytes(s, "ascii")).hexdigest()
         return checksum[:4]
 
     def getEncryptedMaster(self):


### PR DESCRIPTION
This closes #176 . However, this uncovers another bug, #181 .