### PR TITLE
Removed '@' from construct_identifier.

### DIFF
--- a/steem/cli.py
+++ b/steem/cli.py
@@ -1366,11 +1366,11 @@ def format_operation_details(op, memos=False):
     if op[0] == "vote":
         return "%s: %s" % (
             op[1]["voter"],
-            construct_identifier('@', op[1]["author"], op[1]["permlink"]))
+            construct_identifier(op[1]["author"], op[1]["permlink"]))
     elif op[0] == "comment":
         return "%s: %s" % (
             op[1]["author"],
-            construct_identifier('@', op[1]["author"], op[1]["permlink"]))
+            construct_identifier(op[1]["author"], op[1]["permlink"]))
     elif op[0] == "transfer":
         str_ = "%s -> %s %s" % (
             op[1]["from"],

--- a/steem/cli.py
+++ b/steem/cli.py
@@ -175,8 +175,8 @@ def legacyentry():
     parser_upvote.add_argument(
         'post',
         type=str,
-        help='@author/permlink-identifier of the post to upvote ' +
-             'to (e.g. @xeroc/python-steem-0-1)')
+        help='author/permlink-identifier of the post to upvote ' +
+             'to (e.g. xeroc/python-steem-0-1)')
     parser_upvote.add_argument(
         '--account',
         type=str,
@@ -202,8 +202,8 @@ def legacyentry():
     parser_downvote.add_argument(
         'post',
         type=str,
-        help='@author/permlink-identifier of the post to downvote ' +
-             'to (e.g. @xeroc/python-steem-0-1)')
+        help='author/permlink-identifier of the post to downvote ' +
+             'to (e.g. xeroc/python-steem-0-1)')
     parser_downvote.add_argument(
         '--weight',
         type=float,
@@ -584,7 +584,7 @@ def legacyentry():
     parser_resteem.add_argument(
         'identifier',
         type=str,
-        help='@author/permlink-identifier of the post to resteem')
+        help='author/permlink-identifier of the post to resteem')
     parser_resteem.add_argument(
         '--account',
         type=str,
@@ -776,6 +776,7 @@ def legacyentry():
     steem = stm.Steem(no_broadcast=args.no_broadcast, **options)
 
     if args.command == "set":
+        # TODO: Evaluate this line with cli refactor.
         if (args.key in ["default_account"] and args.value[0] == "@"):
             args.value = args.value[1:]
         configStorage[args.key] = args.value
@@ -1011,7 +1012,7 @@ def legacyentry():
             for account in args.account:
                 a = Account(account)
 
-                print("\n@%s" % a.name)
+                print("\n%s" % a.name)
                 t = PrettyTable(["Account", "STEEM", "SBD", "VESTS"])
                 t.align = "r"
                 t.add_row([

--- a/steem/commit.py
+++ b/steem/commit.py
@@ -181,7 +181,7 @@ class Commit(object):
 
         If this post is intended as a reply/comment, `reply_identifier` needs
         to be set with the identifier of the parent post/comment (eg.
-        `@author/permlink`).
+        `author/permlink`).
 
         Optionally you can also set json_metadata, comment_options and upvote
         the newly created post as an author.
@@ -356,7 +356,7 @@ class Commit(object):
         """ Vote for a post
 
             :param str identifier: Identifier for the post to upvote Takes
-                                   the form ``@author/permlink``
+                                   the form ``author/permlink``
             :param float weight: Voting weight. Range: -100.0 - +100.0. May
                                  not be 0.0
             :param str account: Voter to use for voting. (Optional)
@@ -1308,7 +1308,7 @@ class Commit(object):
     def resteem(self, identifier, account=None):
         """ Resteem a post
 
-            :param str identifier: post identifier (@<account>/<permlink>)
+            :param str identifier: post identifier (<account>/<permlink>)
             :param str account: (optional) the account to allow access
                 to (defaults to ``default_account``)
         """

--- a/steem/post.py
+++ b/steem/post.py
@@ -27,7 +27,7 @@ class Post(dict):
 
         Args:
 
-            post (str or dict): ``@author/permlink`` or raw ``comment`` as
+            post (str or dict): ``author/permlink`` or raw ``comment`` as
             dictionary.
 
             steemd_instance (Steemd): Steemd node to connect to
@@ -47,7 +47,7 @@ class Post(dict):
             self.identifier = self.parse_identifier(post)
         elif isinstance(post,
                         dict) and "author" in post and "permlink" in post:
-            post["author"] = post["author"].replace('@', '')
+
             self.identifier = construct_identifier(post["author"],
                                                    post["permlink"])
         else:
@@ -157,7 +157,7 @@ class Post(dict):
     def get_all_replies(root_post=None, comments=list(), all_comments=list()):
         """ Recursively fetch all the child comments, and return them as a list.
 
-        Usage: all_comments = Post.get_all_replies(Post('@foo/bar'))
+        Usage: all_comments = Post.get_all_replies(Post('foo/bar'))
         """
         # see if our root post has any comments
         if root_post:

--- a/steem/post.py
+++ b/steem/post.py
@@ -48,7 +48,7 @@ class Post(dict):
         elif isinstance(post,
                         dict) and "author" in post and "permlink" in post:
             post["author"] = post["author"].replace('@', '')
-            self.identifier = construct_identifier('@', post["author"],
+            self.identifier = construct_identifier(post["author"],
                                                    post["permlink"])
         else:
             raise ValueError("Post expects an identifier or a dict "
@@ -59,7 +59,7 @@ class Post(dict):
     @staticmethod
     def parse_identifier(uri):
         """ Extract post identifier from post URL. """
-        return '@%s' % uri.split('@')[-1]
+        return '%s' % uri.split('@')[-1]
 
     def refresh(self):
         post_author, post_permlink = resolve_identifier(self.identifier)
@@ -144,7 +144,7 @@ class Post(dict):
             category = m.group(1)
             author = m.group(2)
             permlink = m.group(3)
-            return construct_identifier('@', author, permlink), category
+            return construct_identifier(author, permlink), category
 
     def get_replies(self):
         """ Return **first-level** comments of the post.
@@ -276,7 +276,7 @@ class Post(dict):
                 log.info("No changes made! Skipping ...")
                 return
 
-        reply_identifier = construct_identifier('@',
+        reply_identifier = construct_identifier(
             original_post["parent_author"], original_post["parent_permlink"])
 
         new_meta = {}

--- a/steem/post.py
+++ b/steem/post.py
@@ -58,8 +58,8 @@ class Post(dict):
 
     @staticmethod
     def parse_identifier(uri):
-        """ Extract post identifier from post URL. """
-        return '%s' % uri.split('@')[-1]
+        """ Extract canonical post id/url (i.e. strip any leading `@`). """
+        return uri.split('@')[-1]
 
     def refresh(self):
         post_author, post_permlink = resolve_identifier(self.identifier)

--- a/steem/steemd.py
+++ b/steem/steemd.py
@@ -108,7 +108,7 @@ class Steemd(HttpClient):
             :param str sort: Sort the list by "recent" or "payout"
             :param str category: Only show posts in this category
             :param str start: Show posts after this post. Takes an
-                              identifier of the form ``@author/permlink``
+                              identifier of the form ``author/permlink``
         """
 
         discussion_query = {

--- a/steem/utils.py
+++ b/steem/utils.py
@@ -251,6 +251,8 @@ def construct_identifier(*args):
         raise ValueError(
             'construct_identifier() received unparsable arguments')
 
+    # remove the @ sign in case it was passed in by the user.
+    author = author.replace('@', '')
     fields = dict(author=author, permlink=permlink)
     return "{author}/{permlink}".format(**fields)
 
@@ -288,7 +290,11 @@ def derive_permlink(title, parent_permlink=None):
 
 
 def resolve_identifier(identifier):
-    match = re.match("@?([\w\-\.]*)/([\w\-]*)", identifier)
+
+    # in case the user supplied the @ sign.
+    identifier = identifier.replace('@', '')
+
+    match = re.match("([\w\-\.]*)/([\w\-]*)", identifier)
     if not hasattr(match, "group"):
         raise ValueError("Invalid identifier")
     return match.group(1), match.group(2)

--- a/steem/utils.py
+++ b/steem/utils.py
@@ -231,20 +231,16 @@ def remove_from_dict(obj, remove_keys=list()):
     return {k: v for k, v in items if k not in remove_keys}
 
 
-def construct_identifier(username_prefix='@', *args):
+def construct_identifier(*args):
     """ Create a post identifier from comment/post object or arguments.
 
     Examples:
 
         ::
-            construct_identifier('@', 'username', 'permlink')
-            construct_identifier('@', {'author': 'username',
+            construct_identifier('username', 'permlink')
+            construct_identifier({'author': 'username',
                 'permlink': 'permlink'})
     """
-    # https://github.com/steemit/steem-python/issues/165
-    # this is assert here will be removed with the above issue
-    # addressed.
-    assert(username_prefix == '@')
 
     if len(args) == 1:
         op = args[0]
@@ -255,8 +251,8 @@ def construct_identifier(username_prefix='@', *args):
         raise ValueError(
             'construct_identifier() received unparsable arguments')
 
-    fields = dict(prefix=username_prefix, author=author, permlink=permlink)
-    return "{prefix}{author}/{permlink}".format(**fields)
+    fields = dict(author=author, permlink=permlink)
+    return "{author}/{permlink}".format(**fields)
 
 
 def json_expand(json_op, key_name='json'):

--- a/tests/steem/test_utils.py
+++ b/tests/steem/test_utils.py
@@ -11,7 +11,7 @@ from steem.utils import (
 
 class Testcases(unittest.TestCase):
     def test_constructIdentifier(self):
-        self.assertEqual(construct_identifier('@', "A", "B"), "@A/B")
+        self.assertEqual(construct_identifier("A", "B"), "A/B")
 
     def test_sanitizePermlink(self):
         self.assertEqual(sanitize_permlink("aAf_0.12"), "aaf-0-12")

--- a/tests/steem/test_utils.py
+++ b/tests/steem/test_utils.py
@@ -23,7 +23,7 @@ class Testcases(unittest.TestCase):
         self.assertEqual(derive_permlink("[](){}"), "")
 
     def test_resolveIdentifier(self):
-        self.assertEqual(resolve_identifier("@A/B"), ("A", "B"))
+        self.assertEqual(resolve_identifier("A/B"), ("A", "B"))
 
     def test_formatTime(self):
         self.assertEqual(fmt_time(1463480746), "20160517t102546")


### PR DESCRIPTION
`construct_identifier` was responsible for formatting the permlink, and had wonky handling of the '@' at the beginning of the permlink. Removed to improve clarity.