### PR TITLE
assume appbase, downgrade on error

### DIFF
--- a/steembase/http_client.py
+++ b/steembase/http_client.py
@@ -224,7 +224,7 @@ class HttpClient(object):
                             HttpClient.downgraded.add(self.url)
                             continue
 
-                    raise RPCError("RPC {}: {}".format(self.url, message))
+                    raise RPCError("RPC Error - Node: {} Body: {} Error: {}".format(self.url, str(body), message))
 
                 if return_with_args:
                     return result['result'], args

--- a/steembase/http_client.py
+++ b/steembase/http_client.py
@@ -148,26 +148,25 @@ class HttpClient(object):
 
         """
 
-        # if kwargs is non-empty after this, we pass it to steemd
+        # if kwargs is non-empty after this, it becomes the call params
         as_json = kwargs.pop('as_json', True)
         api = kwargs.pop('api', None)
         _id = kwargs.pop('_id', 0)
 
-        # we pass `args` to steemd. kwargs overrides, if present.
+        # `kwargs` for object-style param, `args` for list-style. pick one.
         assert not (kwargs and args), 'fail - passed array AND object args'
-        if kwargs:
-            args = kwargs
+        params = kwargs if kwargs else args
 
         if api:
             body = {'jsonrpc': '2.0',
                     'id': _id,
                     'method': 'call',
-                    'params': [api, name, args]}
+                    'params': [api, name, params]}
         else:
             body = {'jsonrpc': '2.0',
                     'id': _id,
                     'method': name,
-                    'params': args}
+                    'params': params}
 
         if as_json:
             return json.dumps(body, ensure_ascii=False).encode('utf8')

--- a/tests/steem/test_broadcast.py
+++ b/tests/steem/test_broadcast.py
@@ -15,7 +15,7 @@ def test_transfer():
     else:
         raise Exception('expected RPCError')
 
-    assert 'missing required active authority' in rpc_error
+    assert 'tx_missing_active_auth' in rpc_error
 
 
 def test_claim_reward():
@@ -34,7 +34,7 @@ def test_claim_reward():
     else:
         raise Exception('expected RPCError')
 
-    assert 'missing required posting authority' in rpc_error
+    assert 'tx_missing_posting_auth' in rpc_error
 
 
 def test_witness_update():
@@ -58,4 +58,4 @@ def test_witness_update():
     else:
         raise Exception('expected RPCError')
 
-    assert 'missing required active authority' in rpc_error
+    assert 'tx_missing_active_auth' in rpc_error

--- a/tests/steem/test_steemd.py
+++ b/tests/steem/test_steemd.py
@@ -10,6 +10,13 @@ def test_get_version():
     assert version[0:4] == '0.19'
 
 
+def test_get_dgp():
+    """ We should be able to call get_dynamic_global_properties on steemd """
+    s = Steemd()
+    response = s.call('get_dynamic_global_properties', api='database_api')
+    assert response['head_block_number'] > 20e6
+
+
 def test_ensured_block_ranges():
     """ Post should load correctly if passed a dict or string identifier. """
     s = Steemd()


### PR DESCRIPTION
Resolve #164

 - Assume provided nodes are running appbase and use condenser_api.
 - Check for a specific error that a non-appbase node would return
   - If present, save the endpoint to a 'downgraded` registry, and retry

This PR changes exception flow -- it is more thorough and retries are more reliable.