### PR TITLE
Python 2.7 compat layer for Types.JsonObj

### DIFF
--- a/steem/commit.py
+++ b/steem/commit.py
@@ -134,13 +134,13 @@ class Commit(object):
         return tx.broadcast()
 
     def sign(self, unsigned_trx, wifs=[]):
-        """ Sign a provided transaction witht he provided key(s)
+        """ Sign a provided transaction with the provided key(s)
 
             :param dict unsigned_trx: The transaction to be signed and returned
             :param string wifs: One or many wif keys to use for signing
                 a transaction. If not present, the keys will be loaded
                 from the wallet as defined in "missing_signatures" key
-                of the transactizions.
+                of the transactions.
         """
         tx = TransactionBuilder(
             unsigned_trx,

--- a/steem/transactionbuilder.py
+++ b/steem/transactionbuilder.py
@@ -114,9 +114,9 @@ class TransactionBuilder(dict):
 
         try:
             signedtx = SignedTransaction(**self.json())
-        except:  # noqa FIXME(sneak)
-            raise ValueError("Invalid TransactionBuilder Format")
-
+        except Exception as e:  # noqa FIXME(sneak)
+            # raise ValueError("Invalid TransactionBuilder Format")
+            print("TransactionBuilder Error: {}".format(e.message))
         if not any(self.wifs):
             raise MissingKeyError
 

--- a/steem/transactionbuilder.py
+++ b/steem/transactionbuilder.py
@@ -115,8 +115,8 @@ class TransactionBuilder(dict):
         try:
             signedtx = SignedTransaction(**self.json())
         except Exception as e:  # noqa FIXME(sneak)
-            # raise ValueError("Invalid TransactionBuilder Format")
-            print("TransactionBuilder Error: {}".format(e.message))
+            raise e
+
         if not any(self.wifs):
             raise MissingKeyError
 

--- a/steem/utils.py
+++ b/steem/utils.py
@@ -385,6 +385,29 @@ def compat_compose_dictionary(dictionary, **kwargs):
     return composed_dict
 
 
+def compat_json(data, ignore_dicts=False):
+    """
+
+    :param data: Json Data we want to ensure compatibility on.
+    :param ignore_dicts: should only be set to true when first called.
+    :return: Python compatible 2.7 byte-strings when encountering unicode.
+    """
+    # if this is a unicode string, return its string representation
+    if isinstance(data, unicode):
+        return data.encode('utf-8')
+    # if this is a list of values, return list of byte-string values
+    if isinstance(data, list):
+        return [compat_json(item, ignore_dicts=True) for item in data]
+    # if this is a dictionary, return dictionary of byte-string keys and values
+    # but only if we haven't already byte-string it
+    if isinstance(data, dict) and not ignore_dicts:
+        return {
+            compat_json(key, ignore_dicts=True): compat_json(value, ignore_dicts=True)
+            for key, value in data.iteritems()
+        }
+    # if it's anything else, return it in its original form
+    return data
+
 def compat_bytes(item, encoding=None):
     """
     This method is required because Python 2.7 `bytes` is simply an alias for `str`. Without this method,

--- a/steembase/types.py
+++ b/steembase/types.py
@@ -1,10 +1,11 @@
 import json
+import sys
 import struct
 import time
 import array
 from binascii import hexlify, unhexlify
 from calendar import timegm
-from steem.utils import compat_bytes
+from steem.utils import compat_bytes, compat_json
 
 object_type = {
     "dynamic_global_property": 0,
@@ -66,8 +67,12 @@ def JsonObj(data):
     """ Returns json object from data
     """
     try:
-        return json.loads(str(data))
-    except:  # noqa FIXME(sneak)
+        if sys.version >= '3.0':
+            return json.loads(str(data))
+        else:
+            return compat_json(json.loads(str(data), object_hook=compat_json),
+                               ignore_dicts=True)
+    except Exception as e:  # noqa FIXME(sneak)
         try:
             return data.__str__()
         except:  # noqa FIXME(sneak)


### PR DESCRIPTION
`types.JsonObj` would occasionally generate unicode data due to the functionality of `json.loads`. The `compat_json` method was pulled from [this stackoverflow question](https://stackoverflow.com/questions/956867/how-to-get-string-objects-instead-of-unicode-from-json/13105359#13105359). This is a crucial fix for Python 2.7 support.