### PR TITLE
exception cleanup, fix retriable rpc errs

### DIFF
--- a/steem/blockchain.py
+++ b/steem/blockchain.py
@@ -156,23 +156,19 @@ class Blockchain(object):
 
         def reliable_query(_client, _method, _api, *_args):
             # this will ALWAYS eventually return, at all costs
-            retval = None
-            while retval is None:
+            while True:
                 try:
-                    retval = _client.call(_method, *_args, api=_api)
+                    return _client.call(_method, *_args, api=_api)
                 except Exception as e:
-                    logger.info(
-                        'Failed to get response',
+                    logger.error(
+                        'Error: %s' % str(s),
                         extra=dict(
                             exc=e,
                             response=retval,
                             api_name=_api,
                             api_method=_method,
                             api_args=_args))
-                    retval = None
-                if retval is None:
                     time.sleep(1)
-            return retval
 
         def get_reliable_block_interval(_client):
             return reliable_query(_client, 'get_config',

--- a/steem/steem.py
+++ b/steem/steem.py
@@ -91,10 +91,8 @@ class Steem:
             return
 
         def __call__(self, *args, **kwargs):
+            assert not (args and kwargs), "specified both args and kwargs"
             if len(kwargs) > 0:
-                if len(args) > 0:
-                    raise RPCError(
-                        "Cannot specify both args and kwargs in RPC")
                 return self.exec_method(
                     self.method_name, kwargs=kwargs, api=self.api_name)
             return self.exec_method(self.method_name, *args, api=self.api_name)

--- a/steembase/exceptions.py
+++ b/steembase/exceptions.py
@@ -21,6 +21,10 @@ class RPCError(Exception):
     pass
 
 
+class RPCErrorRecoverable(RPCError):
+    pass
+
+
 class NumRetriesReached(Exception):
     pass
 


### PR DESCRIPTION
`RPCError` now represents all non-recoverable errors. All errors are assumed to be non-recoverable except for (1) steemd lock error and (2) steemd unknown exception, which will now be thrown as `RPCErrorRecoverable`.

Also removed cruft from `reliable_query` and stopped silencing errors.