### PR TITLE
Added JSONDecodeError to list of retriable errors

### DIFF
--- a/steem/__init__.py
+++ b/steem/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from .steem import Steem
 
-__version__ = '0.18.103'
+__version__ = '1.0.0'

--- a/steembase/http_client.py
+++ b/steembase/http_client.py
@@ -217,7 +217,7 @@ class HttpClient(object):
 
         # tuple of Exceptions which are eligible for retry
         retry_exceptions = (MaxRetryError, ReadTimeoutError,
-                            ProtocolError, RPCErrorRecoverable,)
+                            ProtocolError, RPCErrorRecoverable, json.decoder.JSONDecodeError,)
         if sys.version > '3.0':
             retry_exceptions += (RemoteDisconnected, ConnectionResetError,)
         else:

--- a/steembase/http_client.py
+++ b/steembase/http_client.py
@@ -281,7 +281,7 @@ class HttpClient(object):
 
             except retry_exceptions as e:
                 if e == ValueError and 'JSON' not in e.args[0]:
-                    raise e
+                    raise e # (python<3.5 lacks json.decoder.JSONDecodeError)
                 if tries >= 10:
                     logging.error('Failed after %d attempts -- %s', tries, e)
                     raise e

--- a/tests/steem/test_transactions.py
+++ b/tests/steem/test_transactions.py
@@ -812,14 +812,6 @@ class Testcases(unittest.TestCase):
         rpc = self.steem.commit.wallet
         compare = rpc.serialize_transaction(tx.json())
 
-        pprint(tx.json())
-
-        print("\n")
-        print(compare[:-130])
-        print(tx_wire[:-130])
-        print("\n")
-
-        print(tx_wire[:-130] == compare[:-130])
         self.assertEqual(compare[:-130], tx_wire[:-130])
 
 


### PR DESCRIPTION
This will allow for node cycling when a node is down or fat-fingered when initially set.