### PR TITLE
Added branch in bip38 for Python 2.7 compatibility.

### DIFF
--- a/steem/cli.py
+++ b/steem/cli.py
@@ -1335,7 +1335,13 @@ def confirm(question, default="yes"):
         raise ValueError("invalid default answer: '%s'" % default)
     while True:
         sys.stdout.write(question + prompt)
-        choice = input().lower()
+        # Python 2.7 `input` attempts to evaluate the input, while in 3+
+        # it returns a string. Python 2.7 `raw_input` returns a str as desired.
+        if sys.version >= '3.0':
+            choice = input().lower()
+        else:
+            choice = raw_input().lower()
+
         if default is not None and choice == '':
             return valid[default]
         elif choice in valid:

--- a/steembase/bip38.py
+++ b/steembase/bip38.py
@@ -1,5 +1,6 @@
 import hashlib
 import logging
+import os
 import sys
 from binascii import hexlify, unhexlify
 
@@ -14,7 +15,7 @@ try:
 except ImportError:
     raise ImportError("Missing dependency: pycrypto")
 
-SCRYPT_MODULE = None
+SCRYPT_MODULE = os.environ.get('SCRYPT_MODULE', None)
 if not SCRYPT_MODULE:
     try:
         import scrypt

--- a/steembase/bip38.py
+++ b/steembase/bip38.py
@@ -28,6 +28,17 @@ if not SCRYPT_MODULE:
             SCRYPT_MODULE = "pylibscrypt"
         except ImportError:
             raise ImportError("Missing dependency: scrypt or pylibscrypt")
+elif 'pylibscrypt' in SCRYPT_MODULE:
+    try:
+        import pylibscrypt as scrypt
+    except ImportError:
+        raise ImportError("Missing dependency: pylibscrypt explicitly set but missing")
+elif 'scrypt' in SCRYPT_MODULE:
+    try:
+        import scrypt
+    except ImportError:
+            raise ImportError("Missing dependency: scrypt explicitly set but missing")
+
 
 log.debug("Using scrypt module: %s" % SCRYPT_MODULE)
 

--- a/steembase/bip38.py
+++ b/steembase/bip38.py
@@ -56,7 +56,10 @@ def encrypt(privkey, passphrase):
     a = compat_bytes(addr, 'ascii')
     salt = hashlib.sha256(hashlib.sha256(a).digest()).digest()[0:4]
     if SCRYPT_MODULE == "scrypt":
-        key = scrypt.hash(passphrase, salt, 16384, 8, 8)
+        if sys.version >= '3.0.0':
+            key = scrypt.hash(passphrase, salt, 16384, 8, 8)
+        else:
+            key = scrypt.hash(str(passphrase), str(salt), 16384, 8, 8)
     elif SCRYPT_MODULE == "pylibscrypt":
         key = scrypt.scrypt(compat_bytes(passphrase, "utf-8"), salt, 16384, 8, 8)
     else:

--- a/steembase/bip38.py
+++ b/steembase/bip38.py
@@ -73,8 +73,8 @@ def encrypt(privkey, passphrase):
             b'\x01' + b'\x42' + b'\xc0' + salt + encrypted_half1 + encrypted_half2)
     " Checksum "
     checksum = hashlib.sha256(hashlib.sha256(payload).digest()).digest()[:4]
-    privatkey = hexlify(payload + checksum).decode('ascii')
-    return Base58(privatkey)
+    privatekey = hexlify(payload + checksum).decode('ascii')
+    return Base58(privatekey)
 
 
 def decrypt(encrypted_privkey, passphrase):
@@ -97,7 +97,10 @@ def decrypt(encrypted_privkey, passphrase):
     salt = d[0:4]
     d = d[4:-4]
     if SCRYPT_MODULE == "scrypt":
-        key = scrypt.hash(passphrase, salt, 16384, 8, 8)
+        if sys.version >= '3.0.0':
+            key = scrypt.hash(passphrase, salt, 16384, 8, 8)
+        else:
+            key = scrypt.hash(str(passphrase), str(salt), 16384, 8, 8)
     elif SCRYPT_MODULE == "pylibscrypt":
         key = scrypt.scrypt(compat_bytes(passphrase, "utf-8"), salt, 16384, 8, 8)
     else:

--- a/tests/steembase/test_bip38.py
+++ b/tests/steembase/test_bip38.py
@@ -7,6 +7,10 @@ class Testcases(unittest.TestCase):
     def test_encrypt(self):
         if 'SCRYPT_MODULE' in os.environ:
             del os.environ['SCRYPT_MODULE']
+        try:
+            del sys.modules['steembase.bip38']
+        except KeyError:
+            pass
         import steembase.bip38
         self.assertEqual([
             format(
@@ -33,17 +37,24 @@ class Testcases(unittest.TestCase):
     def test_decrypt(self):
         if 'SCRYPT_MODULE' in os.environ:
             del os.environ['SCRYPT_MODULE']
+        try:
+            del sys.modules['steembase.bip38']
+        except KeyError:
+            pass
         import steembase.bip38
         self.assertEqual([
             format(
-                steembase.bip38.decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
-                        "xsUW8epQi", "TestingOneTwoThree"), "wif"),
+                steembase.bip38.decrypt(
+                    "6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
+                    "xsUW8epQi", "TestingOneTwoThree"), "wif"),
             format(
-                steembase.bip38.decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
-                        "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
+                steembase.bip38.decrypt(
+                    "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
+                    "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
             format(
-                steembase.bip38.decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
-                        "PPX1dWByq", "Satoshi"), "wif")
+                steembase.bip38.decrypt(
+                    "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
+                    "PPX1dWByq", "Satoshi"), "wif")
         ], [
             "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd",
             "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
@@ -52,6 +63,10 @@ class Testcases(unittest.TestCase):
 
     def test_encrypt_scrypt(self):
         os.environ['SCRYPT_MODULE'] = 'scrypt'
+        try:
+            del sys.modules['steembase.bip38']
+        except KeyError:
+            pass
         import steembase.bip38
         assert steembase.bip38.SCRYPT_MODULE == 'scrypt'
         self.assertEqual([
@@ -79,18 +94,25 @@ class Testcases(unittest.TestCase):
 
     def test_decrypt_scrypt(self):
         os.environ['SCRYPT_MODULE'] = 'scrypt'
+        try:
+            del sys.modules['steembase.bip38']
+        except KeyError:
+            pass
         import steembase.bip38
         assert steembase.bip38.SCRYPT_MODULE == 'scrypt'
         self.assertEqual([
             format(
-                steembase.bip38.decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
-                        "xsUW8epQi", "TestingOneTwoThree"), "wif"),
+                steembase.bip38.decrypt(
+                    "6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
+                    "xsUW8epQi", "TestingOneTwoThree"), "wif"),
             format(
-                steembase.bip38.decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
-                        "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
+                steembase.bip38.decrypt(
+                    "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
+                    "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
             format(
-                steembase.bip38.decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
-                        "PPX1dWByq", "Satoshi"), "wif")
+                steembase.bip38.decrypt(
+                    "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
+                    "PPX1dWByq", "Satoshi"), "wif")
         ], [
             "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd",
             "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
@@ -100,6 +122,10 @@ class Testcases(unittest.TestCase):
 
     def test_encrypt_pylibscrypt(self):
         os.environ['SCRYPT_MODULE'] = 'pylibscrypt'
+        try:
+            del sys.modules['steembase.bip38']
+        except KeyError:
+            pass
         import steembase.bip38
         assert steembase.bip38.SCRYPT_MODULE == 'pylibscrypt'
         self.assertEqual([
@@ -127,24 +153,32 @@ class Testcases(unittest.TestCase):
 
     def test_decrypt_pylibscrypt(self):
         os.environ['SCRYPT_MODULE'] = 'pylibscrypt'
+        try:
+            del sys.modules['steembase.bip38']
+        except KeyError:
+            pass
         import steembase.bip38
         assert steembase.bip38.SCRYPT_MODULE == 'pylibscrypt'
         self.assertEqual([
             format(
-                steembase.bip38.decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
-                        "xsUW8epQi", "TestingOneTwoThree"), "wif"),
+                steembase.bip38.decrypt(
+                    "6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
+                    "xsUW8epQi", "TestingOneTwoThree"), "wif"),
             format(
-                steembase.bip38.decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
-                        "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
+                steembase.bip38.decrypt(
+                    "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
+                    "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
             format(
-                steembase.bip38.decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
-                        "PPX1dWByq", "Satoshi"), "wif")
+                steembase.bip38.decrypt(
+                    "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
+                    "PPX1dWByq", "Satoshi"), "wif")
         ], [
             "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd",
             "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
             "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"
         ])
         del os.environ['SCRYPT_MODULE']
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/steembase/test_bip38.py
+++ b/tests/steembase/test_bip38.py
@@ -28,7 +28,7 @@ class Testcases(unittest.TestCase):
             "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq"
         ])
 
-    def test_deencrypt(self):
+    def test_decrypt(self):
         self.assertEqual([
             format(
                 decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
@@ -44,7 +44,6 @@ class Testcases(unittest.TestCase):
             "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
             "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"
         ])
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/steembase/test_bip38.py
+++ b/tests/steembase/test_bip38.py
@@ -5,20 +5,22 @@ from steembase.account import PrivateKey
 
 class Testcases(unittest.TestCase):
     def test_encrypt(self):
-        from steembase.bip38 import encrypt
+        if 'SCRYPT_MODULE' in os.environ:
+            del os.environ['SCRYPT_MODULE']
+        import steembase.bip38
         self.assertEqual([
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd"),
                     "TestingOneTwoThree"), "encwif"),
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR"),
                     "TestingOneTwoThree"), "encwif"),
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"),
                     "Satoshi"), "encwif")
@@ -29,16 +31,18 @@ class Testcases(unittest.TestCase):
         ])
 
     def test_decrypt(self):
-        from steembase.bip38 import decrypt
+        if 'SCRYPT_MODULE' in os.environ:
+            del os.environ['SCRYPT_MODULE']
+        import steembase.bip38
         self.assertEqual([
             format(
-                decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
+                steembase.bip38.decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
                         "xsUW8epQi", "TestingOneTwoThree"), "wif"),
             format(
-                decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
+                steembase.bip38.decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
                         "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
             format(
-                decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
+                steembase.bip38.decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
                         "PPX1dWByq", "Satoshi"), "wif")
         ], [
             "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd",
@@ -48,20 +52,21 @@ class Testcases(unittest.TestCase):
 
     def test_encrypt_scrypt(self):
         os.environ['SCRYPT_MODULE'] = 'scrypt'
-        from steembase.bip38 import encrypt
+        import steembase.bip38
+        assert steembase.bip38.SCRYPT_MODULE == 'scrypt'
         self.assertEqual([
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd"),
                     "TestingOneTwoThree"), "encwif"),
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR"),
                     "TestingOneTwoThree"), "encwif"),
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"),
                     "Satoshi"), "encwif")
@@ -70,44 +75,46 @@ class Testcases(unittest.TestCase):
             "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
             "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq"
         ])
-        os.environ['SCRYPT_MODULE'] = ''
+        del os.environ['SCRYPT_MODULE']
 
     def test_decrypt_scrypt(self):
         os.environ['SCRYPT_MODULE'] = 'scrypt'
-        from steembase.bip38 import decrypt
+        import steembase.bip38
+        assert steembase.bip38.SCRYPT_MODULE == 'scrypt'
         self.assertEqual([
             format(
-                decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
+                steembase.bip38.decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
                         "xsUW8epQi", "TestingOneTwoThree"), "wif"),
             format(
-                decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
+                steembase.bip38.decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
                         "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
             format(
-                decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
+                steembase.bip38.decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
                         "PPX1dWByq", "Satoshi"), "wif")
         ], [
             "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd",
             "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
             "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"
         ])
-        os.environ['SCRYPT_MODULE'] = ''
+        del os.environ['SCRYPT_MODULE']
 
     def test_encrypt_pylibscrypt(self):
         os.environ['SCRYPT_MODULE'] = 'pylibscrypt'
-        from steembase.bip38 import encrypt
+        import steembase.bip38
+        assert steembase.bip38.SCRYPT_MODULE == 'pylibscrypt'
         self.assertEqual([
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd"),
                     "TestingOneTwoThree"), "encwif"),
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR"),
                     "TestingOneTwoThree"), "encwif"),
             format(
-                encrypt(
+                steembase.bip38.encrypt(
                     PrivateKey(
                         "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"),
                     "Satoshi"), "encwif")
@@ -116,27 +123,28 @@ class Testcases(unittest.TestCase):
             "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
             "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq"
         ])
-        os.environ['SCRYPT_MODULE'] = ''
+        del os.environ['SCRYPT_MODULE']
 
     def test_decrypt_pylibscrypt(self):
         os.environ['SCRYPT_MODULE'] = 'pylibscrypt'
-        from steembase.bip38 import decrypt
+        import steembase.bip38
+        assert steembase.bip38.SCRYPT_MODULE == 'pylibscrypt'
         self.assertEqual([
             format(
-                decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
+                steembase.bip38.decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
                         "xsUW8epQi", "TestingOneTwoThree"), "wif"),
             format(
-                decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
+                steembase.bip38.decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
                         "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
             format(
-                decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
+                steembase.bip38.decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
                         "PPX1dWByq", "Satoshi"), "wif")
         ], [
             "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd",
             "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
             "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"
         ])
-        os.environ['SCRYPT_MODULE'] = ''
+        del os.environ['SCRYPT_MODULE']
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/steembase/test_bip38.py
+++ b/tests/steembase/test_bip38.py
@@ -1,11 +1,11 @@
 import unittest
-
+import os
 from steembase.account import PrivateKey
-from steembase.bip38 import encrypt, decrypt
 
 
 class Testcases(unittest.TestCase):
     def test_encrypt(self):
+        from steembase.bip38 import encrypt
         self.assertEqual([
             format(
                 encrypt(
@@ -29,6 +29,7 @@ class Testcases(unittest.TestCase):
         ])
 
     def test_decrypt(self):
+        from steembase.bip38 import decrypt
         self.assertEqual([
             format(
                 decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
@@ -44,6 +45,98 @@ class Testcases(unittest.TestCase):
             "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
             "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"
         ])
+
+    def test_encrypt_scrypt(self):
+        os.environ['SCRYPT_MODULE'] = 'scrypt'
+        from steembase.bip38 import encrypt
+        self.assertEqual([
+            format(
+                encrypt(
+                    PrivateKey(
+                        "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd"),
+                    "TestingOneTwoThree"), "encwif"),
+            format(
+                encrypt(
+                    PrivateKey(
+                        "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR"),
+                    "TestingOneTwoThree"), "encwif"),
+            format(
+                encrypt(
+                    PrivateKey(
+                        "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"),
+                    "Satoshi"), "encwif")
+        ], [
+            "6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxThxsUW8epQi",
+            "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
+            "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq"
+        ])
+        os.environ['SCRYPT_MODULE'] = ''
+
+    def test_decrypt_scrypt(self):
+        os.environ['SCRYPT_MODULE'] = 'scrypt'
+        from steembase.bip38 import decrypt
+        self.assertEqual([
+            format(
+                decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
+                        "xsUW8epQi", "TestingOneTwoThree"), "wif"),
+            format(
+                decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
+                        "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
+            format(
+                decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
+                        "PPX1dWByq", "Satoshi"), "wif")
+        ], [
+            "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd",
+            "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
+            "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"
+        ])
+        os.environ['SCRYPT_MODULE'] = ''
+
+    def test_encrypt_pylibscrypt(self):
+        os.environ['SCRYPT_MODULE'] = 'pylibscrypt'
+        from steembase.bip38 import encrypt
+        self.assertEqual([
+            format(
+                encrypt(
+                    PrivateKey(
+                        "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd"),
+                    "TestingOneTwoThree"), "encwif"),
+            format(
+                encrypt(
+                    PrivateKey(
+                        "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR"),
+                    "TestingOneTwoThree"), "encwif"),
+            format(
+                encrypt(
+                    PrivateKey(
+                        "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"),
+                    "Satoshi"), "encwif")
+        ], [
+            "6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxThxsUW8epQi",
+            "6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg",
+            "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq"
+        ])
+        os.environ['SCRYPT_MODULE'] = ''
+
+    def test_decrypt_pylibscrypt(self):
+        os.environ['SCRYPT_MODULE'] = 'pylibscrypt'
+        from steembase.bip38 import decrypt
+        self.assertEqual([
+            format(
+                decrypt("6PRN5mjUTtud6fUXbJXezfn6oABoSr6GSLjMbrGXRZxSUcxTh"
+                        "xsUW8epQi", "TestingOneTwoThree"), "wif"),
+            format(
+                decrypt("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEb"
+                        "n2Nh2ZoGg", "TestingOneTwoThree"), "wif"),
+            format(
+                decrypt("6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTe"
+                        "PPX1dWByq", "Satoshi"), "wif")
+        ], [
+            "5HqUkGuo62BfcJU5vNhTXKJRXuUi9QSE6jp8C3uBJ2BVHtB8WSd",
+            "5KN7MzqK5wt2TP1fQCYyHBtDrXdJuXbUzm4A9rKAteGu3Qi5CVR",
+            "5HtasZ6ofTHP6HCwTqTkLDuLQisYPah7aUnSKfC7h4hMUVw2gi5"
+        ])
+        os.environ['SCRYPT_MODULE'] = ''
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/steembase/test_bip38.py
+++ b/tests/steembase/test_bip38.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import sys
 from steembase.account import PrivateKey
 
 

--- a/tests/steembase/test_bip38_pylibscrypt.py
+++ b/tests/steembase/test_bip38_pylibscrypt.py
@@ -1,12 +1,13 @@
 import unittest
 import os
-import sys
 from steembase.account import PrivateKey
-import steembase.bip38
 
 
 class Testcases(unittest.TestCase):
-    def test_encrypt(self):
+
+    def test_encrypt_pylibscrypt(self):
+        os.environ['SCRYPT_MODULE'] = 'pylibscrypt'
+        import steembase.bip38
         self.assertEqual([
             format(
                 steembase.bip38.encrypt(
@@ -29,7 +30,9 @@ class Testcases(unittest.TestCase):
             "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq"
         ])
 
-    def test_decrypt(self):
+    def test_decrypt_pylibscrypt(self):
+        os.environ['SCRYPT_MODULE'] = 'pylibscrypt'
+        import steembase.bip38
         self.assertEqual([
             format(
                 steembase.bip38.decrypt(

--- a/tests/steembase/test_bip38_scrypt.py
+++ b/tests/steembase/test_bip38_scrypt.py
@@ -1,12 +1,13 @@
 import unittest
 import os
-import sys
 from steembase.account import PrivateKey
-import steembase.bip38
 
 
 class Testcases(unittest.TestCase):
-    def test_encrypt(self):
+
+    def test_encrypt_scrypt(self):
+        os.environ['SCRYPT_MODULE'] = 'scrypt'
+        import steembase.bip38
         self.assertEqual([
             format(
                 steembase.bip38.encrypt(
@@ -29,7 +30,9 @@ class Testcases(unittest.TestCase):
             "6PRNFFkZc2NZ6dJqFfhRoFNMR9Lnyj7dYGrzdgXXVMXcxoKTePPX1dWByq"
         ])
 
-    def test_decrypt(self):
+    def test_decrypt_scrypt(self):
+        os.environ['SCRYPT_MODULE'] = 'scrypt'
+        import steembase.bip38
         self.assertEqual([
             format(
                 steembase.bip38.decrypt(


### PR DESCRIPTION
Closes #181 

`scrypt.hash` requires that the password and salt are `str` in Python 2.7. This PR adds a code path to bip38.py that typecasts the values to strings.

All tests are passing, however I'm not certain this will entirely fix the issue, if there are passwords that have illegal characters in them, this will fail.