### PR TITLE
Community - fix missing positional argument: mode

### DIFF
--- a/steembase/bip38.py
+++ b/steembase/bip38.py
@@ -77,7 +77,7 @@ def encrypt(privkey, passphrase):
     else:
         raise ValueError("No scrypt module loaded")
     (derived_half1, derived_half2) = (key[:32], key[32:])
-    aes = AES.new(derived_half2,AES.MODE_ECB)
+    aes = AES.new(derived_half2, AES.MODE_ECB)
     encrypted_half1 = _encrypt_xor(privkeyhex[:32], derived_half1[:16], aes)
     encrypted_half2 = _encrypt_xor(privkeyhex[32:], derived_half1[16:], aes)
     " flag byte is forced 0xc0 because Graphene only uses compressed keys "
@@ -121,7 +121,7 @@ def decrypt(encrypted_privkey, passphrase):
     derivedhalf2 = key[32:64]
     encryptedhalf1 = d[0:16]
     encryptedhalf2 = d[16:32]
-    aes = AES.new(derivedhalf2,AES.MODE_ECB)
+    aes = AES.new(derivedhalf2, AES.MODE_ECB)
     decryptedhalf2 = aes.decrypt(encryptedhalf2)
     decryptedhalf1 = aes.decrypt(encryptedhalf1)
     privraw = decryptedhalf1 + decryptedhalf2


### PR DESCRIPTION
Local PR for @AlexChien #245:

> when run command
> ```
> steempy addkey
> ```
> and input proper wif key and have wallet unlocked, it throws 
> 
> ```
> new() missing 1 required positional argument: 'mode'
> ```
> 
> fixed by recommendation found at https://steemit.com/steemdev/@anthonyadavisii/steem-python-bip38-wallet-error-with-fix