### PR TITLE
Note to consider private chains on ASSET evaluation

### DIFF
--- a/steembase/operations.py
+++ b/steembase/operations.py
@@ -18,7 +18,7 @@ asset_precision = {
     "STEEM": 3,
     "VESTS": 6,
     "SBD": 3,
-}
+} # this DICT blocks operations on private chains, need to pull assets from /steembase/chains.py `known_chains` 
 
 
 class Operation:


### PR DESCRIPTION
The current state only evaluates for the 3 main assets for private chains this blocks operations. 
check `/steembase/chains.py` 

```
from chain import know_chains
Iterate ASSETS
```

I tried to fetch the current prefix from `steemd.chain_params`

```
    @property
    def chain_params(self):
        """ Identify the connected network. This call returns a
            dictionary with keys chain_id, prefix, and other chain
            specific settings
        """
        props = self.get_dynamic_global_properties()
        chain = props["current_supply"].split(" ")[1]

        assert chain in known_chains, "The chain you are connecting " + \
                                      "to is not supported"
        return known_chains.get(chain)

```

Leaving it here to come back to it when time allows, quick and dirty solution would be to just replace your ASSET names there or use the NAI